### PR TITLE
Implement create_backup

### DIFF
--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -156,3 +156,11 @@ class Controller:
             if ap.get('state', 0) == 1 and ap.get('name', None) == name:
                 self.reboot_ap(ap['mac'])
 
+    def create_backup(self):
+        """Ask controller to create a backup archive file, response contains the path to the backup file."""
+
+        js = json.dumps({'cmd':'backup'})
+        params = urllib.urlencode({'json': js})
+        answer = self._read(self.url + 'api/cmd/system', params)
+
+        return answer[0].get('url')


### PR DESCRIPTION
Adds function to tell the UniFi controller to prepare a fresh
.unf backup archive that can then be downloaded. The obtained
file can be used to restore a UniFi controller via GUI or at
initial setup.

JSON command obtained via publicly available API shell sample code
for UniFi 2.4.4 (http://www.ubnt.com/downloads/unifi/2.4.4/unifi_sh_api)

Apparently no authentication is required for the file, once it has been
created by the server. Tested with basic urllib.urlretrieve and plain wget.
