### PR TITLE
Complete backup methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ Remove a client from the block list.
 
  - `mac` -- the MAC address of the client to unblock.
 
+### `create_backup(self)`
+
+Tells the controller to create a backup archive that can be downloaded with download_backup() and
+then  be used to restore a controller on another machine.
+
+Remember that this puts significant load on a controller for some time (depending on the amount of users and managed APs).
+
+### `get_backup(self, targetfile)`
+
+Tells the controller to create a backup archive and downloads it to a file. It should have a .unf extension for later restore.
+
+ - `targetfile` -- the target file name, you can also use a full path. Default creates unifi-backup.unf in the current directoy.
+
 License
 -------
 

--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -172,8 +172,9 @@ class Controller:
     def get_backup(self, target_file='unifi-backup.unf'):
         """Get a backup archive from a controller.
 
-        Creates, then downloads a backup archive to a specified file.
-        It should have a .unf extension for restore.
+        Arguments:
+            target_file -- Filename or full path to download the backup archive to, should have .unf extension for restore.
+
         """
         download_path = self.create_backup()
 

--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -157,10 +157,29 @@ class Controller:
                 self.reboot_ap(ap['mac'])
 
     def create_backup(self):
-        """Ask controller to create a backup archive file, response contains the path to the backup file."""
+        """Ask controller to create a backup archive file, response contains the path to the backup file.
 
-        js = json.dumps({'cmd':'backup'})
+        Warning: This process puts significant load on the controller may
+                 render it partially unresponsive for other requests.
+        """
+
+        js = json.dumps({'cmd': 'backup'})
         params = urllib.urlencode({'json': js})
         answer = self._read(self.url + 'api/cmd/system', params)
 
         return answer[0].get('url')
+
+    def get_backup(self, target_file='unifi-backup.unf'):
+        """Get a backup archive from a controller.
+
+        Creates, then downloads a backup archive to a specified file.
+        It should have a .unf extension for restore.
+        """
+        download_path = self.create_backup()
+
+        opener = self.opener.open(self.url + downlodad_path)
+        unifi_archive = opener.read()
+
+        backupfile = open(target_file, 'w')
+        backupfile.write(unifi_archive)
+        backupfile.close()


### PR DESCRIPTION
I almost forgot that I used to have an ugly hack for the cookie required for the backup download, otherwise you'll only get a garbage file that you can't restore.

Thus I created the download method since always re-creating for downloads puts high load on production systems. This is also the cause for adding a note in the doc and the code. 

Example: A dual core controller VM with 70 APs takes up 3 minutes to complete and other requests may time out in the meantime. I heavily depends on the size of the controller.

Since we have no doc if the backup file is stored, or thrown away after a session I assume we have to create it before dowloading it. But you can download a backup as many times as you whish after creating it during a session. Restoring the resulting file workd from a 2.4.5 production controller to another 2.4.5 test controller.

Feel free to criticise as usual as it's your code. :-)
