### PR TITLE
Import 2 functions from unifi-lab: get_users and get_user_groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ Return a list of all AP:s, with significant information about each.
 ### `get_clients(self)`
 
 Return a list of all active clients, with significant information about each.
- 
+
+### `get_users(self)`
+
+Return a list of all known clients, with significant information about each.
+
+### `get_user_groups(self)`
+
+Return a list of user groups with its rate limiting settings.
+
 ### `get_wlan_conf(self)`
 
 Return a list of configured WLANs with their configuration parameters.

--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -111,6 +111,16 @@ class Controller:
 
         return self._read(self.api_url + 'stat/sta')
 
+    def get_users(self):
+        """Return a list of all known clients, with significant information about each."""
+		
+        return self._read(self.api_url + 'list/user')
+
+    def get_user_groups(self):
+        """Return a list of user groups with its rate limiting settings."""
+		
+        return self._read(self.api_url + 'list/usergroup')
+
     def get_wlan_conf(self):
         """Return a list of configured WLANs with their configuration parameters."""
 


### PR DESCRIPTION
Obtained via unifi-lab, adds 2 simple functions to get more
user an configuration data.

get_users likely represents a couple of things that are shown
in the "All Clients" tab of UniFi's web interface. (though not all)

In contrast to get_clients, it shows both curently connected as well
as disconnected clients. Infortunately I don't have knowledge about
how long exactly this data is stored in the DB, but it seems to store
quite some data back in time.

get_user_groups gives mostly QoS rate limitation information
about user groups defined in the web interface.
