### PR TITLE
Add alias API.

### DIFF
--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -360,3 +360,10 @@ class Controller:
         js = {'mac': guest_mac}
 
         return self._run_command(cmd, params=js)
+
+    def alias(self, user, name):
+        if 'user_id' in user:
+            user = user['user_id']
+        js = json.dumps({'name': name})
+        params = urllib.urlencode({'json': js})
+        return self._read(self.api_url + 'upd/user/' + user, params)


### PR DESCRIPTION
Work giving a `client` from `get_clients` or a user _id, we may add an if on `_id` to make it work with a `user` from `get_users` if everybody is OK with this way to work.
