### PR TITLE
Fix login to v4 controller with python v3.  Generalize login procedure.

### DIFF
--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -143,17 +143,14 @@ class Controller:
     def _login(self, version):
         log.debug('login() as %s', self.username)
 
+        params = {'username': self.username, 'password': self.password}
         login_url = self.url
+
         if version is 'v4':
             login_url += 'api/login'
+            params = json.dumps(params)
         else:
             login_url += 'login'
-
-        params = {'username': self.username, 'password': self.password}
-
-        if version is 'v4':
-            params = str(params)
-        else:
             params.update({'login': 'login'})
             if PYTHON_VERSION is 2:
                 params = urllib.urlencode(params)

--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -142,18 +142,28 @@ class Controller:
 
     def _login(self, version):
         log.debug('login() as %s', self.username)
-        
-        if(version == 'v4'):
-            params = "{'username':'" + self.username + "','password':'" + self.password + "'}"
-            self.opener.open(self.url + 'api/login', params).read()
+
+        login_url = self.url
+        if version is 'v4':
+            login_url += 'api/login'
         else:
-            if PYTHON_VERSION == 2:
-                params = urllib.urlencode({'login': 'login',
-                                   'username': self.username, 'password': self.password})
-            elif PYTHON_VERSION == 3:
-                params = urllib.parse.urlencode({'login': 'login',
-                                   'username': self.username, 'password': self.password}).encode("UTF-8")
-            self.opener.open(self.url + 'login', params).read()
+            login_url += 'login'
+
+        params = {'username': self.username, 'password': self.password}
+
+        if version is 'v4':
+            params = str(params)
+        else:
+            params.update({'login': 'login'})
+            if PYTHON_VERSION is 2:
+                params = urllib.urlencode(params)
+            elif PYTHON_VERSION is 3:
+                params = urllib.parse.urlencode(params)
+
+        if PYTHON_VERSION is 3:
+            params = params.encode("UTF-8")
+
+        self.opener.open(login_url, params).read()
 
     def _logout(self):
         log.debug('logout()')


### PR DESCRIPTION
Previous code did not work using python v3 and using a Unifi v4 controller.   Also generalized the login procedure to reduce some duplication.
