### PR TITLE
Update controller.py

### DIFF
--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -4,7 +4,7 @@ try:
     # urllib2.URLError: <urlopen error [Errno 1] _ssl.c:504:
     # error:14077438:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert internal error>
     import _ssl
-    _ssl.PROTOCOL_SSLv23 = _ssl.PROTOCOL_TLSv1
+    _ssl.PROTOCOL_SSLv23 = _ssl.PROTOCOL_TLSv2
 except:
     pass
 


### PR DESCRIPTION
since version 
unifi 5.4.18-9252                  all                          Ubiquiti UniFi server
when trying to connect to the server via TLSv1 there is an error message.
It must be TLSv2!